### PR TITLE
feat: add draft post support

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -65,6 +65,7 @@ type post struct {
 	AuthorImg   string        `yaml:"author_image"`
 	CoverImg    string        `yaml:"cover_image"`
 	Date        string        `yaml:"date"`
+	Draft       bool          `yaml:"draft"`
 	Link        string        `yaml:"link"`
 	Content     template.HTML `yaml:"-"`
 }
@@ -155,6 +156,11 @@ func generateSite(cfg *config) error {
 		p, err := parseMarkdown(fbytes)
 		if err != nil {
 			return fmt.Errorf("error parsing markdown: %w", err)
+		}
+
+		if p.Draft {
+			fmt.Printf("skipping draft: %s\n", p.Title)
+			continue
 		}
 
 		p.Link = fmt.Sprintf("%s-%s.html", p.Date, strings.ReplaceAll(p.Title, " ", "_"))

--- a/cmd/post.go
+++ b/cmd/post.go
@@ -89,13 +89,13 @@ func createPost(cfg *config) error {
 		p.Description = "Replace this with a short description of the post"
 	}
 
-	// create frontmatter from form values
 	frontmatter := fmt.Sprintf(`---
 title: %s
 date: %s
 author: %s
 author_image: %s
 description: %s
+draft: true
 ---
 
 Your post content goes here!


### PR DESCRIPTION
Posts with `draft: true` in front matter are skipped during site generation. Prints `skipping draft: <title>` so you know it was seen but excluded.

**Changes:**
- Add `Draft bool` field to the `post` struct (`yaml:"draft"`)
- Skip posts where `draft: true` during `ssg generate`
- `ssg post` now scaffolds new posts with `draft: true` by default

**Usage:**
```yaml
---
title: My New Post
date: 2026-03-20
draft: true    # remove or set to false to publish
---
```

No breaking changes — posts without the `draft` field behave as before (published).