### PR TITLE
feat: add draft mode for posts

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -65,6 +65,7 @@ type post struct {
 	AuthorImg   string        `yaml:"author_image"`
 	CoverImg    string        `yaml:"cover_image"`
 	Date        string        `yaml:"date"`
+	Draft       bool          `yaml:"draft"`
 	Link        string        `yaml:"link"`
 	Content     template.HTML `yaml:"-"`
 }
@@ -155,6 +156,10 @@ func generateSite(cfg *config) error {
 		p, err := parseMarkdown(fbytes)
 		if err != nil {
 			return fmt.Errorf("error parsing markdown: %w", err)
+		}
+
+		if p.Draft && !includeDrafts {
+			continue
 		}
 
 		p.Link = fmt.Sprintf("%s-%s.html", p.Date, strings.ReplaceAll(p.Title, " ", "_"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
+var (
+	cfgFile       string
+	includeDrafts bool
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -54,6 +57,7 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ssg.yaml)")
+	rootCmd.PersistentFlags().BoolVar(&includeDrafts, "drafts", false, "include draft posts")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.


### PR DESCRIPTION
Posts with 'draft: true' in front matter are now excluded from site generation by default. Use --drafts flag with generate or watch to include them.