### PR TITLE
feat: add --drafts flag to include draft posts

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -159,7 +159,7 @@ func generateSite(cfg *config) error {
 			return fmt.Errorf("error parsing markdown: %w", err)
 		}
 
-		if p.Draft {
+		if p.Draft && !includeDrafts {
 			fmt.Printf("skipping draft: %s\n", p.Title)
 			continue
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
+var (
+	cfgFile       string
+	includeDrafts bool
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -54,6 +57,7 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ssg.yaml)")
+	rootCmd.PersistentFlags().BoolVar(&includeDrafts, "drafts", false, "include draft posts")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.


### PR DESCRIPTION
Adds a `--drafts` persistent flag to `generate` and `watch` commands. Draft posts are still skipped by default, but passing `--drafts` includes them for local preview.

Builds on the draft filtering from #7.