### PR TITLE
fix: sort posts newest first on index page

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -176,7 +176,7 @@ func generateSite(cfg *config) error {
 		},
 		"sortByDate": func(posts []post) []post {
 			sort.Slice(posts, func(i, j int) bool {
-				return posts[i].Date < posts[j].Date
+				return posts[i].Date > posts[j].Date
 			})
 			return posts
 		},


### PR DESCRIPTION
The `sortByDate` template function sorted ascending (oldest first). Flips to descending so the most recent post appears at the top.