### PR TITLE
fix: sanitize post titles in generated filenames

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -164,7 +164,7 @@ func generateSite(cfg *config) error {
 			continue
 		}
 
-		p.Link = fmt.Sprintf("%s-%s.html", p.Date, strings.ReplaceAll(p.Title, " ", "_"))
+		p.Link = fmt.Sprintf("%s-%s.html", p.Date, slugify(p.Title))
 
 		siteData.Posts = append(siteData.Posts, p)
 	}
@@ -317,6 +317,14 @@ func copyFile(src, dst string) error {
 	}
 
 	return nil
+}
+
+var nonAlphanumeric = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+
+func slugify(s string) string {
+	s = strings.ReplaceAll(s, " ", "_")
+	s = nonAlphanumeric.ReplaceAllString(s, "")
+	return s
 }
 
 func init() {


### PR DESCRIPTION
Strip special characters (`?`, `&`, etc.) from post link slugs so titles like "Can You Defer Financial Planning to an AI Agent?" produce valid URLs.